### PR TITLE
Adding basic instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,114 @@
 # Osmosis Bindings
 
-CosmWasm bindings to custom Osmosis features
+CosmWasm bindings to custom Osmosis features.
+
+## Prerequisites
+
+Before starting, make sure you have [rustup](https://rustup.rs/) along with a
+recent `rustc` and `cargo` version installed. Currently, we are testing on 1.58.1+.
+
+And you need to have the `wasm32-unknown-unknown` target installed as well.
+
+You can check that via:
+
+```sh
+rustc --version
+cargo --version
+rustup target list --installed
+# if wasm32 is not listed above, run this
+rustup target add wasm32-unknown-unknown
+```
+
+## running tests
+```
+cargo test --locked
+```
+
+## Compile
+```
+cargo build --locked
+```
+
+## generate schema for osmosis contract
+
+```
+cd contracts/reflect
+cargo schema --locked
+```
+This will give you a schema at contracts/reflect/schema/
+
+
+## build contract
+
+```
+cd contracts/reflect
+cargo wasm
+```
+
+
+### Understanding the tests
+
+The main code is in `src/contract.rs` and the unit tests there run in pure rust,
+which makes them very quick to execute and give nice output on failures, especially
+if you do `RUST_BACKTRACE=1 cargo unit-test`.
+
+We consider testing critical for anything on a blockchain, and recommend to always keep
+the tests up to date.
+
+## Generating JSON Schema
+
+While the Wasm calls (`instantiate`, `execute`, `query`) accept JSON, this is not enough
+information to use it. We need to expose the schema for the expected messages to the
+clients. You can generate this schema by calling `cargo schema`, which will output
+4 files in `./schema`, corresponding to the 3 message types the contract accepts,
+as well as the internal `State`.
+
+These files are in standard json-schema format, which should be usable by various
+client side tools, either to auto-generate codecs, or just to validate incoming
+json wrt. the defined schema.
+
+## Preparing the Wasm bytecode for production
+
+Before we upload it to a chain, we need to ensure the smallest output size possible,
+as this will be included in the body of a transaction. We also want to have a
+reproducible build process, so third parties can verify that the uploaded Wasm
+code did indeed come from the claimed rust code.
+
+To solve both these issues, we have produced `rust-optimizer`, a docker image to
+produce an extremely small build output in a consistent manner. The suggest way
+to run it is this:
+
+```sh
+docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  cosmwasm/rust-optimizer:0.12.4
+```
+
+Or, If you're on an arm64 machine, you should use a docker image built with arm64.
+```sh
+docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  cosmwasm/rust-optimizer-arm64:0.12.4
+```
+
+We must mount the contract code to `/code`. You can use a absolute path instead
+of `$(pwd)` if you don't want to `cd` to the directory first. The other two
+volumes are nice for speedup. Mounting `/code/target` in particular is useful
+to avoid docker overwriting your local dev files with root permissions.
+Note the `/code/target` cache is unique for each contract being compiled to limit
+interference, while the registry cache is global.
+
+This is rather slow compared to local compilations, especially the first compile
+of a given contract. The use of the two volume caches is very useful to speed up
+following compiles of the same contract.
+
+This produces an `artifacts` directory with a `PROJECT_NAME.wasm`, as well as
+`checksums.txt`, containing the Sha256 hash of the wasm file.
+The wasm file is compiled deterministically (anyone else running the same
+docker on the same git commit should get the identical file with the same Sha256 hash).
+It is also stripped and minimized for upload to a blockchain (we will also
+gzip it in the uploading process to make it even smaller).
+
 


### PR DESCRIPTION
Reverse engineered the CI to document basic commands. Copied additional information from cw-template repo. Needs a lot of work but it's a good starting place.

Part of #2 