### PR TITLE
Add support for the JoinPool message

### DIFF
--- a/packages/bindings-test/src/multitest.rs
+++ b/packages/bindings-test/src/multitest.rs
@@ -340,6 +340,13 @@ impl Module for OsmosisModule {
                     events: vec![],
                 })
             }
+            OsmosisMsg::JoinPool { pool_id, share_out_amount, token_in_maxs } => 
+            {
+                Ok(AppResponse{
+                    data: None,
+                    events: vec![]
+                })
+            },
         }
     }
 

--- a/packages/bindings-test/src/multitest.rs
+++ b/packages/bindings-test/src/multitest.rs
@@ -168,6 +168,39 @@ impl Pool {
             },
         }
     }
+
+    pub fn join_pool(
+        mut self,
+        asset1: &Coin,
+        asset2: &Coin,
+        pool_id: u64,
+        _share_out_amount: Uint128,
+    ) -> PoolStateResponse {
+        let asset1_denom = &asset1.denom;
+        let asset2_denom = &asset2.denom;
+        let asset1_deposit = asset1.amount;
+        let asset2_deposit = asset2.amount;
+        let (denom1_bal, denom2_bal) = (
+            self.get_amount(&asset1_denom.to_string()),
+            self.get_amount(&asset2_denom.to_string()),
+        );
+        let new_denom1_bal = denom1_bal.unwrap() + asset1_deposit;
+        let new_denom2_bal = denom2_bal.unwrap() + asset2_deposit;
+        self.set_amount(&asset1_denom.to_string(), new_denom1_bal)
+            .unwrap();
+        self.set_amount(&asset2_denom.to_string(), new_denom2_bal)
+            .unwrap();
+        self.shares = (new_denom1_bal * new_denom2_bal).isqrt();
+
+        let denom = self.gamm_denom(pool_id);
+        PoolStateResponse {
+            assets: self.assets,
+            shares: Coin {
+                denom,
+                amount: self.shares,
+            },
+        }
+    }
 }
 
 pub struct OsmosisModule {}
@@ -340,13 +373,25 @@ impl Module for OsmosisModule {
                     events: vec![],
                 })
             }
-            OsmosisMsg::JoinPool { pool_id, share_out_amount, token_in_maxs } => 
-            {
-                Ok(AppResponse{
-                    data: None,
-                    events: vec![]
+            OsmosisMsg::JoinPool {
+                pool_id,
+                share_out_amount,
+                token_in_maxs,
+            } => {
+                let pool = POOLS.load(storage, pool_id)?;
+                let res = pool.join_pool(
+                    &token_in_maxs[0],
+                    &token_in_maxs[1],
+                    pool_id,
+                    share_out_amount,
+                );
+
+                let data = Some(to_binary(&res)?);
+                Ok(AppResponse {
+                    data,
+                    events: vec![],
                 })
-            },
+            }
         }
     }
 
@@ -501,7 +546,7 @@ impl OsmosisApp {
 mod tests {
     use super::*;
     use cosmwasm_std::testing::MOCK_CONTRACT_ADDR;
-    use cosmwasm_std::{coin, from_slice, Uint128};
+    use cosmwasm_std::{coin, from_binary, from_slice, Uint128};
     use cw_multi_test::Executor;
     use osmo_bindings::{Step, Swap};
 
@@ -970,5 +1015,57 @@ mod tests {
         let SwapResponse { amount } = app.wrap().query(&query.into()).unwrap();
         let expected = SwapAmount::In(Uint128::new(2007));
         assert_eq!(amount, expected);
+    }
+
+    #[test]
+    fn perform_join_pool() {
+        let pool1 = Pool::new(coin(12_000_000, "uosmo"), coin(240_000_000, "uatom"));
+        let provider = Addr::unchecked("provider");
+
+        // set up pools
+        let mut app = OsmosisApp::new();
+        app.init_modules(|router, _, storage| {
+            router.custom.set_pool(storage, 1, &pool1).unwrap();
+            router
+                .bank
+                .init_balance(
+                    storage,
+                    &provider,
+                    vec![coin(12_000, "uosmo"), coin(240_000, "uatom")],
+                )
+                .unwrap()
+        });
+
+        let query = OsmosisQuery::PoolState { id: 1 }.into();
+        let state: PoolStateResponse = app.wrap().query(&query).unwrap();
+        assert_eq!(
+            state,
+            PoolStateResponse {
+                shares: Coin {
+                    denom: "gamm/pool/1".to_string(),
+                    amount: Uint128::new(53665631)
+                },
+                assets: vec![coin(12000000u128, "uosmo"), coin(240000000u128, "uatom")]
+            }
+        );
+
+        let msg = OsmosisMsg::JoinPool {
+            pool_id: 1,
+            share_out_amount: Uint128::new(53665),
+            token_in_maxs: vec![coin(12_000, "uosmo"), coin(240_000, "uatom")],
+        };
+
+        let res = app.execute(provider.clone(), msg.into()).unwrap();
+
+        assert_eq!(
+            from_binary::<PoolStateResponse>(&res.data.unwrap()).unwrap(),
+            PoolStateResponse {
+                shares: Coin {
+                    denom: "gamm/pool/1".to_string(),
+                    amount: Uint128::new(53719297)
+                },
+                assets: vec![coin(12012000u128, "uosmo"), coin(240240000u128, "uatom")]
+            }
+        );
     }
 }

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::SwapAmountWithLimit;
 use crate::{Step, Swap};
-use cosmwasm_std::{CosmosMsg, CustomMsg, Uint128, Coin};
+use cosmwasm_std::{Coin, CosmosMsg, CustomMsg, Uint128};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -30,11 +30,11 @@ pub enum OsmosisMsg {
         route: Vec<Step>,
         amount: SwapAmountWithLimit,
     },
-    JoinPool{
+    JoinPool {
         pool_id: u64,
         share_out_amount: Uint128,
-        token_in_maxs: Vec<Coin>
-    }
+        token_in_maxs: Vec<Coin>,
+    },
 }
 
 impl OsmosisMsg {

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::SwapAmountWithLimit;
 use crate::{Step, Swap};
-use cosmwasm_std::{CosmosMsg, CustomMsg, Uint128};
+use cosmwasm_std::{CosmosMsg, CustomMsg, Uint128, Coin};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -30,6 +30,11 @@ pub enum OsmosisMsg {
         route: Vec<Step>,
         amount: SwapAmountWithLimit,
     },
+    JoinPool{
+        pool_id: u64,
+        share_out_amount: Uint128,
+        token_in_maxs: Vec<Coin>
+    }
 }
 
 impl OsmosisMsg {


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support for the JoinPoolMsg.  It adds the `JoinPool` message to the `OsmosisMsg` enum.  There is a unit test that follows the lead of previously written unit tests.

> Add a description of the overall background and high level changes that this PR introduces
This pull request increases the feasibility of creating fully fledged Cosmwasm smart contracts that interact with the Osmosis chain.

## Brief Changelog

  - JoinPool is added to OsmosisMsg


## Testing and Verifying

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates that the shares of a given pool change when joining a pool.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? The changes provide a wrapper around the function: (`x/gamm/keeper/pool_service/JoinPoolNoSwap`)  